### PR TITLE
Add support for .NET 9.0 in project file

### DIFF
--- a/src/MiniExcel/MiniExcelLibs.csproj
+++ b/src/MiniExcel/MiniExcelLibs.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net45;netstandard2.0;net8.0;</TargetFrameworks>
+		<TargetFrameworks>net45;netstandard2.0;net8.0;net9.0</TargetFrameworks>
 		<Version>1.39.0</Version>
 	</PropertyGroup>
 	<PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
Updated TargetFrameworks in MiniExcelLibs.csproj to include 'net9.0', expanding support beyond net45, netstandard2.0, and net8.0.