### PR TITLE
Refactor conditional formatting range processing

### DIFF
--- a/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
+++ b/src/MiniExcel/SaveByTemplate/ExcelOpenXmlTemplate.Impl.cs
@@ -837,23 +837,13 @@ namespace MiniExcelLibs.OpenXml.SaveByTemplate
                         foreach (var conditionalFormat in conditionalFormats) {
                             var newConditionalFormat = conditionalFormat.Node.Clone();
                             var sqref = newConditionalFormat.Attributes["sqref"];
-                            var ranges = conditionalFormat.Ranges.Select(r => 
-                            {
-                                if (r.ContainsRow(originRowIndex))
-                                {
-                                    return new Range() 
-                                    { 
-                                        StartColumn = r.StartColumn,
-                                        StartRow = enumrowstart + 1,
-                                        EndColumn = r.EndColumn,
-                                        EndRow = enumrowend + 1
-                                    };
-                                }
-                                else 
-                                {
-                                    return r;
-                                }
-                            }).ToList();
+                            var ranges = conditionalFormat.Ranges.Where(r => r.ContainsRow(originRowIndex)).Select(r => new Range() 
+                                { 
+                                    StartColumn = r.StartColumn,
+                                    StartRow = enumrowstart,
+                                    EndColumn = r.EndColumn,
+                                    EndRow = enumrowend
+                                }).ToList();
                             sqref.Value = string.Join(" ", ranges.Select(r => $"{ColumnHelper.GetAlphabetColumnName(r.StartColumn)}{r.StartRow}:{ColumnHelper.GetAlphabetColumnName(r.EndColumn)}{r.EndRow}"));
                             newConditionalFormatRanges.Remove(conditionalFormat);
                             newConditionalFormatRanges.Add(new ConditionalFormatRange {


### PR DESCRIPTION
Fixed an issue causing ranges to be set incorrectly. Additionally, if a format covers more than 1 range, the format is copied for each range, ensuring correctness. This could probably be optimized to remain under one range in the future. 